### PR TITLE
Compare XML comments

### DIFF
--- a/lib/nokogiri/diff/xml/node.rb
+++ b/lib/nokogiri/diff/xml/node.rb
@@ -22,7 +22,7 @@ class Nokogiri::XML::Node
         (self.name == node.name && self.value == node.value)
       when Nokogiri::XML::Element, Nokogiri::XML::DTD
         self.name == node.name
-      when Nokogiri::XML::Text
+      when Nokogiri::XML::Text, Nokogiri::XML::Comment
         self.text == node.text
       else
         false


### PR DESCRIPTION
Without this patch, this happens:

``` ruby
require 'nokogiri/diff'

xml = "<!-- Foo -->"
doc = Nokogiri::XML(xml)
doc2 = Nokogiri::XML(xml)

doc.diff(doc2) do |change, node|
  puts "#{change} #{node.inspect}"
end
```

```
- #<Nokogiri::XML::Comment:0x3fe3ca11b3fc " Foo ">
+ #<Nokogiri::XML::Comment:0x3fe3ca11b370 " Foo ">
```

After the patch, it recognizes that both documents are the same.
